### PR TITLE
Issue 21: Details added to maven functions

### DIFF
--- a/src/main/java/group22/ci/MavenResult.java
+++ b/src/main/java/group22/ci/MavenResult.java
@@ -1,8 +1,12 @@
 package group22.ci;
 
+/**
+ * Class used to store the information given with the results of each maven command call
+ */
 public class MavenResult{
 	Boolean result;
 	String message;
+	String details = "";
 	
 	public MavenResult (Boolean result, String message){
 		this.result = result;
@@ -15,5 +19,13 @@ public class MavenResult{
 	
 	public String getMessage (){
 		return message;
+	}
+	
+	public void setDetails(String details){
+		this.details = details;
+	}
+	
+	public String getDetails(){
+		return details;
 	}
 }


### PR DESCRIPTION
Runtime and date of execution is now added to the standard message for both
maven compile and test. A details String has been added to the MavenResult object
that stores additional information about running the tests, such as the amount
of tests run and what failures there where

Fixes #21 